### PR TITLE
NEW RELEASE : versionCode="9", versionName="0.2.2"

### DIFF
--- a/OT/features_list/v9_022.txt
+++ b/OT/features_list/v9_022.txt
@@ -1,0 +1,42 @@
+NEW RELEASE : versionCode="9", versionName="0.2.2"
+
+NEW FEATURES: created several vocabulary errors' recovery processes.
+when are missing: 
+ - vocabulary.json				=> ask user whether correcting  (retrieving info from the first net_xxxxxx) or deleting the voc (then send to vocabularies)
+ - net_xxxxx.json 				=> remove its pb
+ - net_xxxxx.pb are missing.	=> remove its json
+
+NEW BEHAVIOUR: nets' sLabel are now limited to USER or COMMON ADAPTED. several recoding to implement this
+
+BUG-FIX: when creating a new voc as a copy of an existing one.  sModelFileName is now set to "".
+BUG-FIX: when checking the training progress. did not clear timer in catch
+BUG-FIX: after testing a net, it remained the loaded one, and next loadNet failed (as it pointed to a temp dir that was deleted).
+Now, while exiting, RecognitionCtrl unload the tested one and reassign the previous one (if exist)
+
+NEW ENUM:  ENUMS.VOCABULARY.NETJSONFILE_NOTEXIST to manage when a net_xxxx.json is missing
+
+
+VocabularySrv recoded
+
+ - NEW METHOD RuntimeStatusSrv::getUserVocabularyName  returns selected voc
+ - RuntimeStatusSrv::loadVocabulary massively recoded to manage exception's recovery
+
+
+VocabularySrv massively recoded
+
+ - ADDED: 		recoverMissingVocJsonFile
+				recoverMissingNetJsonFile
+				recoverMissingNetPbFile
+				deleteTrainVocabulary
+				getTrainVocabularyFolder
+
+ - REMOVED:		existFeaturesTrainSession (since there could be more recordings [now in a common folder] than features files)
+
+ - MODIFIED:	getTrainVocabulary(path, ignorerecover): may now recover from the following error ENUMS.VOCABULARY.JSONFILE_NOTEXIST or reject it to the caller.
+
+				getTrainVocabularySelectedNet rejects { mycode:ErrorSrv.ENUMS.VOCABULARY.NETJSONFILE_NOTEXIST / NETPBFILE_NOTEXIST, 
+														mydata:retvoc, 
+														message:"....."}
+											  providing data so far obtained and helping caller to manage the recovery process.
+
+

--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<widget android-versionCode="8" id="com.allspeak" version="0.2.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="9" id="com.allspeak" version="0.2.2" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
   <name>AllSpeak</name>
   <description>
         A communication assistive device.

--- a/www/js/controllers/HomeCtrl.js
+++ b/www/js/controllers/HomeCtrl.js
@@ -8,7 +8,7 @@
  *
  */
  
-function HomeCtrl($scope, $ionicPlatform, $ionicPopup, $ionicHistory, $state, InitAppSrv, RuntimeStatusSrv, EnumsSrv, UITextsSrv, RemoteAPISrv)
+function HomeCtrl($scope, $ionicPlatform, $ionicPopup, $ionicHistory, $state, InitAppSrv, RuntimeStatusSrv, EnumsSrv, UITextsSrv, ErrorSrv)
 {
     $scope.$on('$ionicView.enter', function(event, data)
     {
@@ -51,12 +51,21 @@ function HomeCtrl($scope, $ionicPlatform, $ionicPopup, $ionicHistory, $state, In
         })
         .catch(function(error)
         {
-            var msg = "Error in HomeCtrl::$ionicView.enter";
-            if(error.message)
-                msg = msg + " " + error.message;
-                
-            console.log(msg);
-            alert(msg);
+            if(error.mycode == ErrorSrv.ENUMS.VOCABULARY.JSONFILE_NOTEXIST)
+            {        
+                $scope.$apply();
+                // vocabulary json was not present, voc was removed and default was selected. reload the page
+                $state.go("home")
+            }
+            else
+            {
+                var msg = "Error in HomeCtrl::$ionicView.enter";
+                if(error.message)
+                    msg = msg + " " + error.message;
+
+                console.log(msg);
+                alert(msg);
+            }
         });
     });
     

--- a/www/js/controllers/ManageCommandsCtrl.js
+++ b/www/js/controllers/ManageCommandsCtrl.js
@@ -128,7 +128,16 @@ function ManageCommandsCtrl($scope, $state, $ionicHistory, $ionicPlatform, $ioni
                 }
                 else  alert("ERROR in ManageCommandsCtrl::$ionicView.enter. unrecognized modeId: " +  $scope.mode_id.toString());                  
                 $scope.$apply();
-            });
+            })
+            .catch(function(error)
+            {
+                if(error.mycode == ErrorSrv.ENUMS.VOCABULARY.JSONFILE_NOTEXIST)
+                {
+                    // vocabulary could not be recovered or user did not want to do it...and was thus deleted
+                    $state.go("vocabularies"); 
+                }
+                else  alert("ManageCommandsCtrl::$ionicView.enter => " + error.message);
+            });            
         }
         else
         {

--- a/www/js/controllers/VocabulariesCtrl.js
+++ b/www/js/controllers/VocabulariesCtrl.js
@@ -5,7 +5,7 @@
  */
 //function TrainingCtrl($scope, vocabulary)//....use resolve 
 //function TrainingCtrl($scope)  
-function VocabulariesCtrl($scope, $q, $state, $ionicPopup, $ionicHistory, $ionicPlatform, $ionicModal, VocabularySrv, InitAppSrv, FileSystemSrv, RuntimeStatusSrv, EnumsSrv, StringSrv)  
+function VocabulariesCtrl($scope, $q, $state, $ionicPopup, $ionicHistory, $ionicPlatform, $ionicModal, VocabularySrv, InitAppSrv, FileSystemSrv, RuntimeStatusSrv, EnumsSrv, ErrorSrv)  
 {
     $scope.vocabularies             = [];
     $scope.activeVocabulary         = null;
@@ -70,7 +70,6 @@ function VocabulariesCtrl($scope, $q, $state, $ionicPopup, $ionicHistory, $ionic
             var subPromises = [];
             for (var v=0; v<folders.length; v++) 
             {
-                // MISTERIOSAMENTE NON FUNZIONA #ISSUE# ...codice spostato in fondo al file
                 var foldername = folders[v];
                 var active = (foldername == $scope.activeVocabularyName ? true : false);
                 $scope.vocabularies.push({"active": active,"inputjson":$scope.vocabularies_relpath + "/" + foldername + "/" + $scope.jsonvocfilename});
@@ -87,6 +86,14 @@ function VocabulariesCtrl($scope, $q, $state, $ionicPopup, $ionicHistory, $ionic
                         $scope.vocabularies[j].active           = isactive;
                         if(isactive) $scope.activeVocabulary    = $scope.vocabularies[j];
                         return $scope.vocabularies[j];
+                    })
+                    .catch(function(error)
+                    {
+                        if(error.mycode == ErrorSrv.ENUMS.VOCABULARY.JSONFILE_NOTEXIST)
+                        {
+                            // vocabulary could not be recovered or user did not want to do it...and was thus deleted
+                            $state.go("vocabularies"); 
+                        }                        
                     })
                     subPromises.push(subPromise);
                 })(v);           
@@ -177,33 +184,3 @@ function VocabulariesCtrl($scope, $q, $state, $ionicPopup, $ionicHistory, $ionic
     };    
 }
 controllers_module.controller('VocabulariesCtrl', VocabulariesCtrl)
-
-
-
-/*
-//                var foldername = folders[v].name;
-//                var active = (foldername == $scope.activeVocabularyName ? true : false);
-//                $scope.vocabularies.push({"active": active,"sLocalFolder":foldername});
-//                (function(j) 
-//                {
-//                    var localfolder = $scope.vocabularies[j].sLocalFolder;
-//                    var subPromise  = VocabularySrv.getUpdatedStatusName(localfolder)
-//                    .then(function(status) 
-//                    {
-//                        var voc         = status.vocabulary;
-//                        var vocstatus   = status.vocabulary.status;                          
-//                        
-//                        var folder      = $scope.vocabularies[j].sLocalFolder;
-//                        var isactive    = $scope.vocabularies[j].active;
-//                        
-//                        $scope.vocabularies[j]                  = status.vocabulary;
-//                        
-//                        $scope.vocabularies[j].sLocalFolder     = folder;
-//                        $scope.vocabularies[j].active           = isactive;
-//                        $scope.vocabularies[j].sStatus          = vocstatus.label;
-//                        if(isactive) $scope.activeVocabulary    = $scope.vocabularies[j]
-//                    });
-//                    subPromises.push(subPromise);
-//                })(v);
-
- */

--- a/www/js/services/EnumsSrv.js
+++ b/www/js/services/EnumsSrv.js
@@ -11,6 +11,7 @@ function EnumsSrv()
     service.MODALITY    = {};
     service.TRAINING    = {};
     service.VOICEBANK   = {};
+    service.VOCABULARY   = {};
     
     service.RECORD.BY_SENTENCE              = 1001;
     service.RECORD.BY_REPETITIONS           = 1002;
@@ -41,6 +42,8 @@ function EnumsSrv()
     
     service.VOICEBANK.SHOW_ALL              = 1050;
     service.VOICEBANK.SHOW_TRAINED          = 1051;
+    
+    service.VOCABULARY.IGNORE_RECOVERY      = true;
     //==========================================================================
     return service;
 }

--- a/www/js/services/ErrorSrv.js
+++ b/www/js/services/ErrorSrv.js
@@ -16,15 +16,17 @@ function ErrorSrv()
     service.ENUMS.VOCABULARY.JSONFILE_NOTEXIST          = 2002;     // !exist  ../vocabulary.json
     service.ENUMS.VOCABULARY.JSONFILEVARIABLE_EMPTY     = 2003;     // ../vocabulary.json = "" or null
     
-    service.ENUMS.VOCABULARY.MODELFILE_NOTEXIST         = 2004;     // !exist  ../vocabularies/gigi/optomized_XXXX_XXX.pb 
-    service.ENUMS.VOCABULARY.MODELFILEVARIABLE_EMPTY    = 2005;     // ../vocabulary.json = "" or null
+    service.ENUMS.VOCABULARY.NETPBFILE_NOTEXIST         = 2004;     // !exist  ../vocabularies/gigi/net_XXXX_XXX.pb 
+    service.ENUMS.VOCABULARY.NETPBFILEVARIABLE_EMPTY    = 2005;     // ../vocabulary.json = "" or null
     
-    service.ENUMS.VOCABULARY.VOCVARIABLE_EMPTY          = 2006;     // vocabulary           = null
-    service.ENUMS.VOCABULARY.COMMANDSVARIABLE_NULL      = 2007;     // vocabulary.commands  = null
-    service.ENUMS.VOCABULARY.COMMANDSVARIABLE_EMPTY     = 2008;     // vocabulary.commands  = []
+    service.ENUMS.VOCABULARY.NETJSONFILE_NOTEXIST       = 2006;     // !exist  ../vocabularies/gigi/net_XXXX_XXX.json 
     
-    service.ENUMS.VOCABULARY.TRAINFOLDER_NOTEXIST       = 2009;
-    service.ENUMS.VOCABULARY.TRAINFOLDERVARIABLE_EMPTY  = 2010;    
+    service.ENUMS.VOCABULARY.VOCVARIABLE_EMPTY          = 2007;     // vocabulary           = null
+    service.ENUMS.VOCABULARY.COMMANDSVARIABLE_NULL      = 2008;     // vocabulary.commands  = null
+    service.ENUMS.VOCABULARY.COMMANDSVARIABLE_EMPTY     = 2009;     // vocabulary.commands  = []
+    
+    service.ENUMS.VOCABULARY.TRAINFOLDER_NOTEXIST       = 2010;
+    service.ENUMS.VOCABULARY.TRAINFOLDERVARIABLE_EMPTY  = 2011;    
     
     service.ENUMS.VOCABULARY.LOADTFMODEL                = 2015;     // vocabulary.commands  = []
     

--- a/www/js/services/InitAppSrv.js
+++ b/www/js/services/InitAppSrv.js
@@ -53,7 +53,6 @@
 *             
  */
 
-
 function InitAppSrv($http, $q, $cordovaAppVersion, VoiceBankSrv, HWSrv, SpeechDetectionSrv, TfSrv, MfccSrv, VocabularySrv, RemoteAPISrv, FileSystemSrv, RuntimeStatusSrv, EnumsSrv)
 {
     var service                     = {}; 
@@ -246,7 +245,7 @@ function InitAppSrv($http, $q, $cordovaAppVersion, VoiceBankSrv, HWSrv, SpeechDe
         MfccSrv.init(service.config.defaults.mfcc, service.plugin);
         RemoteAPISrv.init(service.config.appConfig.user.api_key, service.config.appConfig.remote, service.plugin, service);    // I pass the current appConfig values (not the defauls ones)
         RuntimeStatusSrv.init(service.config.defaults.file_system.vocabularies_folder, service.config.defaults.file_system.recordings_folder, service);
-        VocabularySrv.init(service.config.defaults.file_system, service.plugin);
+        VocabularySrv.init(service.config.defaults.file_system, service.plugin, service);
     };
     
     //====================================================================================================================

--- a/www/js/services/UITextsSrv.js
+++ b/www/js/services/UITextsSrv.js
@@ -20,6 +20,10 @@ function UITextsSrv()
     service.labelCriticalErrorDesc      = "L\'APPLICAZIONE VERRA\' CHIUSA PER IL SEGUENTE ERRORE:<br>";
     service.labelAdd                    = "AGGIUNGI"; 
     service.labelSubstitute             = "SOSTITUISCI"; 
+    service.labelChange                 = "CAMBIA"; 
+    service.labelCancel                 = "ANNULLA"; 
+    service.labelDelete                 = "CANCELLA"; 
+    service.labelRecovery               = "RECUPERA"; 
     service.labelSureOverWriteExistFile = 'IL FILE ESISTE GIA\'.<br>VUOI SOVRASCRIVERLO ?'; 
     
     
@@ -51,6 +55,7 @@ function UITextsSrv()
     service.TRAINING.labelToggleSentencesShowTrainVocabulary    = "VISUALIZZA I COMANDI";
     service.TRAINING.labelToggleSentencesEditTrainVocabulary    = "MODIFICA I COMANDI";    
     service.TRAINING.labelTrainCommands                         = "ADDESTRA I COMANDI";    
+    service.TRAINING.labelTestNetName                           = "TEST NUOVA: ";    
     
     service.TRAINING.labelVocTrainedWant2Download               = "IL VOCABOLARIO E\' STATO ADDESTRATO. VUOI SCARICARLO ORA ? E\' POSSIBILE FARLO IN SEGUITO";    
     service.TRAINING.labelNetDownloadedWant2TestIt              = "HAI CORRETTAMENTE SCARICATO LA RETE, VUOI ATTIVARLA E PASSARLA AL RICONOSCIMENTO ?";    
@@ -63,12 +68,16 @@ function UITextsSrv()
     service.TRAINING.labelSelTrainingMode                       = 'Seleziona la modalità di addestramento della rete';    
     service.TRAINING.labelLostConnection                        = "HAI PERSO LA CONNESSIONE INTERNET. VERRAI MANDATO ALLA PAGINA PRECEDENTE";    
     
-    service.TRAINING.models.labelC                              = "comune"
-    service.TRAINING.models.labelPU                             = "utente pura"
-    service.TRAINING.models.labelPUA                            = "utente pura adattata"
-    service.TRAINING.models.labelCA                             = "comune adattata"
-    service.TRAINING.models.labelCRA                            = "comune riadattata"
-    service.TRAINING.models.labelPURA                           = "utente pura riadattata"
+    service.TRAINING.models.labelUSER                           = "UTENTE";
+    service.TRAINING.models.labelCOMMONADAPTED                  = "COMUNE ADATTATA";
+    service.TRAINING.models.labelUNSPECIFIED                    = "NON SPECIFICATA";
+    
+    service.TRAINING.models.labelC                              = "comune";
+    service.TRAINING.models.labelPU                             = "utente pura";
+    service.TRAINING.models.labelPUA                            = "utente pura adattata";
+    service.TRAINING.models.labelCA                             = "comune adattata";
+    service.TRAINING.models.labelCRA                            = "comune riadattata";
+    service.TRAINING.models.labelPURA                           = "utente pura riadattata";
     
     
     service.TRAINING.labelNewNetSubstituting                    = "UNA RETE UGUALE ESISTE GIA\'. CONTINUANDO, POTRAI PROVARE LA NUOVA RETE, MA SE L\'ACCETTERAI, LA VECCHIA VERSIONE ORA PRESENTE VERRA\' ELIMINATA.\nVUOI PROSEGUIRE?";    
@@ -81,6 +90,7 @@ function UITextsSrv()
     service.TRAINING.MODAL_CREATE_NEWVOCABULARY                 = "SCEGLI IL NOME DEL VOCABOLARIO DI COMANDI CHE INTENDI ADDESTRARE.IL NOME \"default\" E' RISERVATO AL SISTEMA E NON PUOI UTILIZZARLO. SUGGERIMENTO: SE E' IL PRIMO VOCABOLARIO, CHIAMALO STANDARD";
     
     service.VOCABULARY.CONFIRM_DELETE                           = "VUOI VERAMENTE CANCELLARE IL VOCABOLARIO?";
+    service.VOCABULARY.DELETED                                  = "IL VOCABOLARIO E\' STATO CANCELLATO";
     service.VOCABULARY.USERCOMMAND_EXIST                        = "IL COMANDO GIÀ ESISTE <br> CAMBIAGLI IL NOME";
     service.VOCABULARY.want2registervoiceNewCommand             = "VUOI REGISTRARE LA TUA VOCE MENTRE PRONUNCI QUESTO NUOVO COMANDO ?";
     service.VOCABULARY.labelReservedVocName                     = '\" E\' RISERVATO AL SISTEMA. SCEGLI UN\'ALTRO NOME';
@@ -94,6 +104,11 @@ function UITextsSrv()
     service.VOCABULARY.labelSaveList                            = "SALVA LISTA";
     service.VOCABULARY.labelListSaved                           = "LA LISTA DEI COMANDI E\' STATA CORRETTAMENTE SALVATA";
     service.VOCABULARY.labelAskAddorSubstituteRec               = "AGGIUNGI NUOVE RIPETIZIONI AD UNA SESSIONE ESISTENTE, OPPURE SOSTITUISCI LE RIPETIZIONI PRESENTI";
+    service.VOCABULARY.labelErrorMissingVocabularyJson1         = "SI E\' VERIFICATO UN ERRORE IRREPARABILE SUL VOCABOLARIO:<br>     ";
+    service.VOCABULARY.labelErrorMissingVocabularyJson2         = "      <br>VUOI PROVARE A:<br> - RECUPERARLO<br> - CANCELLARLO";
+    service.VOCABULARY.labelErrorMissingVocabularyJsonVocDeleted= "NON E\' STATO POSSIBILE RECUPERARE IL VOCABOLARIO<br>E\' STATO RIMOSSO";
+    service.VOCABULARY.labelErrorMissingNetJson                 = "SI E\' VERIFICATO UN PROBLEMA CON LA RETE SELEZIONATA CHE VERRA\' CANCELLATA<br>DEVI SELEZIONARLA UN\'ALTRA";
+    service.VOCABULARY.labelErrorMissingNetJsonTestSession      = "SI E\' VERIFICATO UN PROBLEMA CON LA RETE APPENA ADDESTRATA, CHE VERRA\' CANCELLATA<br>DEVI RIPETERE L\'ADDESTRAMENTO";
     
     service.REMOTE.labelConnect                                 = "Connetti questo dispositivo al tuo centro SLA di riferimento";    
     service.REMOTE.labelWant2Connect                            = "Vuoi connettere questo dispositivo al tuo centro SLA di riferimento?";    

--- a/www/templates/manage_training.html
+++ b/www/templates/manage_training.html
@@ -15,12 +15,7 @@
         </ion-nav-buttons>          
     </ion-nav-bar>     
 
-    <ion-footer-bar class="bar-positive">
-        <button class="bu button button-custom button-block button-positive text-big" ng-click="cancel()">RITORNA</button>
-    </ion-footer-bar> 
-    
     <ion-content>
-        
         <div class="card">
             <ion-item class="item item-divider"  style="background-color: #C2A5A5 !important">UTENTE PURA</ion-item>        
             <div class="button-bar">        
@@ -48,6 +43,15 @@
                 <button class="button button-huge button-block button-calm" ng-if="existingNets.ca.exist && existingNets.cra.exist" ng-click="startNewSession(aNetType[4].value, true, existingNets.cra.voc.sessionid)">AGGIORNA</button>
             </div>             
         </div> 
+    </ion-content>    
+    
+    <ion-footer-bar class="bar-positive">
+        <button class="button button-custom button-block button-positive text-big" ng-click="cancel()">RITORNA</button>
+    </ion-footer-bar>     
+    
+</ion-view>
+
+
 
 <!--        <div class="card">
             NEW PURE USER  always present, just change text
@@ -69,125 +73,4 @@
             REPLACE CA or CREATE CRA 
             <button class="button button-big button-block button-calm" ng-if="existingNets.ca.exist && !existingNets.cra.exist" ng-click="startNewSession(aNetType[4].value, false, existingNets.ca.voc.sessionid)">RIADATTA COMUNE</button>
             <button class="button button-big button-block button-calm" ng-if="existingNets.ca.exist && existingNets.cra.exist" ng-click="startNewSession(aNetType[4].value, true, existingNets.cra.voc.sessionid)">RIADATTA COMUNE</button>
-        </div>  -->        
-        
-    </ion-content>    
-</ion-view>
-
-
-
-
-
-
-
-
-
-        
-        
-<!--        <label class="item item-input item-select">
-            <div class="input-label">Tipo analisi</div>
-            <select ng-model="selectedProcScheme" ng-change="updateProcScheme(selectedProcScheme)" ng-options="item.label for item in aProcScheme track by item.value"></select>            
-        </label>     -->
-
-<!--        
-        CREATE/REPLACE COMMON READAPT 
-        <div class="button-bar" ng-if="existingNets.pu.exist && !existingNets.pua.exist">        
-            <button class="button button-block button-maxi button-dark" ng-click="startNewSession(aNetType[1].value, true)">SOSTITUISCI<br>ADATTA COMUNE</button>
-            <button class="button button-block button-maxi button-calm" ng-click="startNewSession(aNetType[3].value, false, existingNets.pu.voc.sessionid)">RIADATTA<br>ADATTA COMUNE</button>
-        </div> 
-        <div class="button-bar" ng-if="existingNets.pu.exist && existingNets.pua.exist">        
-            <button class="button button-block button-maxi button-dark" ng-click="startNewSession(aNetType[1].value, true)">SOSTITUISCI<br>ADATTA COMUNE</button>
-            <button class="button button-block button-maxi button-calm" ng-click="startNewSession(aNetType[3].value, true, existingNets.pu.voc.sessionid)">RIADATTA<br>ADATTA COMUNE</button>
-        </div> 
-        <button class="button button-big button-block button-large button-positive" ng-if="!existingNets.pu.exist" ng-click="startNewSession(aNetType[0].value, false)">UTENTE PURA</button>
-
-        -->
-
-
-<!--        <button class="button button-big button-block button-large button-positive" ng-if="existingNets.pu.exist" ng-click="startNewSession(aNetType[0].value, true)">SOSTITUISCI<br>UTENTE PURA</button>
-        <button class="button button-big button-block button-large button-positive" ng-if="!existingNets.pu.exist" ng-click="startNewSession(aNetType[0].value, false)">UTENTE PURA</button>
-        
-        <button class="button button-big button-block button-large button-positive" ng-if="existingNets.ca.exist" ng-click="startNewSession(aNetType[1].value, true)">SOSTITUISCI<br>ADATTA COMUNE</button>
-        <button class="button button-big button-block button-large button-positive" ng-if="!existingNets.ca.exist" ng-click="startNewSession(aNetType[1].value, false)">ADATTA COMUNE</button>
-        
-         new pure user adapt 
-        <button class="button button-big button-block button-large button-positive" ng-if="existingNets.pu.exist && !existingNets.pua.exist" ng-click="startNewSession(aNetType[2].value, false, existingNets.pu.voc.sessionid)">ADATTA UTENTE</button>
-         replace existing pure user adapt 
-        <button class="button button-big button-block button-large button-positive" ng-if="existingNets.pu.exist && existingNets.pua.exist" ng-click="startNewSession(aNetType[2].value, true, existingNets.pu.voc.sessionid)">SOSTITUISCI<br>ADATTA UTENTE</button>
-        
-        
-         new user re-adapt 
-        <button class="button button-big button-block button-large button-positive" ng-if="(existingNets.ua.exist || existingNets.ca.exist) && !existingNets.pua.exist" ng-click="startNewSession(aNetType[2].value, true, existingNets.pu.voc.sessionid)">ADATTA UTENTE</button>
-        -->
-        
-        
-
-        <!--<div class="item item-divider">STATUS</div>-->
-        
-        <!-- =====================================================-->
-        <!-- =============    BUTTONS / OPS ======================-->
-        <!-- =====================================================-->
-        
-        <!--RECORDINGS-->
-<!--        <ion-item class="item-button-right" ng-if="!vocabulary_status.haveValidTrainingSession">Registrazioni
-            <div class="buttons">
-                <button class="button button-assertive" ng-click="addSession();">
-                    <i class="icon ion-plus-round"></i>
-                </button>
-            </div>                
-        </ion-item>         -->
-        <!--<ion-item class="item-icon-right" ng-if="vocabulary_status.haveValidTrainingSession">Registrazioni<span> <i class="icon ion-checkmark-circled"></i></span></ion-item>-->    
-        <!--<ion-item class="item-icon-right" ng-if="!vocabulary_status.haveValidTrainingSession">Registrazioni<span> <i class="icon ion-close-circled"></i></span></ion-item>-->    
-       
-        <!--FEATURES-->
-<!--        <ion-item class="item-button-right" ng-disabled="!vocabulary_status.haveValidTrainingSession" ng-if="vocabulary_status.haveFeatures.length">Features
-            <div class="buttons">
-                <button class="button button-assertive" ng-click="askExtractFeatures();">
-                    <i class="icon ion-plus-round"></i>
-                </button>
-            </div>                
-        </ion-item>         -->
-        <!--<ion-item class="item-icon-right" ng-if="!vocabulary_status.haveFeatures.length">Features<span><i class="icon ion-checkmark-circled"></i></span></ion-item>-->    
-        <!--<ion-item class="item-icon-right" ng-if="vocabulary_status.haveFeatures.length">Features<span><i class="icon ion-close-circled"></i></span></ion-item>-->    
-       
-<!--        ZIP
-        <ion-item class="item-button-right" ng-if="!vocabulary_status.haveZip">ZIP features
-            <div class="buttons">
-                <button class="button button-assertive" ng-disabled="!vocabulary_status.haveFeatures" ng-click="zipSession();">
-                    <i class="icon ion-plus-round"></i>
-                </button>
-            </div>                
-        </ion-item>         
-        <ion-item class="item-icon-right" ng-if="vocabulary_status.haveZip">ZIP features<span><i class="icon ion-checkmark-circled"></i></span></ion-item>    -->
-       
-        <!--ADDESTRA RETE-->
-<!--        <ion-item class="item-button-right" ng-if="!vocabulary_status.isNetAvailableRemote">Addestra Rete
-            <div class="buttons">
-                <button class="button button-assertive" ng-disabled="!vocabulary_status.haveZip" ng-click="upLoadSession();">
-                    <i class="icon ion-plus-round"></i>
-                </button>
-            </div>                
-        </ion-item>         
-        <ion-item class="item-icon-right" ng-if="vocabulary_status.isNetAvailableRemote">Addestra Rete<span><i class="icon ion-checkmark-circled"></i></span></ion-item>    -->
-        
-        <!--CHIEDI RETE-->
-<!--        <ion-item class="item-button-right" ng-if="isTraining">Controlla rete
-            <div class="buttons">
-                <button class="button button-assertive" ng-click="checkSession();">
-                    <i class="icon ion-plus-round"></i>
-                </button>
-            </div>                
-        </ion-item>         -->
-       
-        <!--SCARICA RETE-->
-<!--        <ion-item class="item-button-right" ng-if="!vocabulary_status.isNetAvailableLocale">Scarica rete
-            <div class="buttons">
-                <button class="button button-assertive" ng-disabled="!vocabulary_status.isNetAvailableRemote" ng-click="addSession();">
-                    <i class="icon ion-plus-round"></i>
-                </button>
-            </div>                
-        </ion-item>         
-        <ion-item class="item-icon-right" ng-if="vocabulary_status.isNetAvailableLocale">Scarica rete<span><i class="icon ion-checkmark-circled"></i></span></ion-item>    -->
-       
-        <!--CARICA RETE-->
-        <!--<ion-toggle class="item" ng-disabled="!vocabulary_status.isNetAvailableLocale" ng-model="toogleSelectAll" ng-click="selectAll(toogleSelectAll)">USA QUESTA RETE</ion-toggle>-->
+        </div>  -->   

--- a/www/templates/modal/popupSubmitSession.html
+++ b/www/templates/modal/popupSubmitSession.html
@@ -1,17 +1,17 @@
 <ion-modal-view>
-    
-<!--    <ion-header-bar class="bar bar-header bar-positive">
-        <h1 class="title">Addestra il vocabolario</h1>
-        <button class="button button-clear button-primary" ng-click="closeModalSubmit()">Cancel</button>
-    </ion-header-bar>    -->
+
+    <ion-footer-bar class="bar-positive">
+        <div class="button-bar">        
+            <button class="bu button button-custom button-block button-positive text-big" ng-click="closeModalSubmit()">CANCELLA</button>
+        </div>          
+    </ion-footer-bar>  
     
     <ion-content>
 
             <div class="item item-divider">STATUS</div>
 
             <!--FEATURES-->
-            <ion-item class="item-icon-right" ng-if="(!isCalcFeatures && !vocabulary_status.haveFeatures.length)">Features<span><i class="icon ion-checkmark-circled"></i></span></ion-item>    
-            <!--<label class="item" ng-if="vocabulary_status.haveFeatures == false">Features</label>--> 
+            <ion-item class="item-icon-right" ng-if="(!isCalcFeatures && vocabulary_status.haveFeatures)">Features<span><i class="icon ion-checkmark-circled"></i></span></ion-item>    
             <label class="item" ng-if="isCalcFeatures">Features : <span class="badge">{{percFiles}} %</span></label> 
 
             <!--ZIP-->
@@ -25,8 +25,8 @@
             
             <!--CHIEDI RETE-->
             <ion-item class="item-icon-right" ng-if="vocabulary_status.isNetAvailableRemote">Controllo Rete<span><i class="icon ion-checkmark-circled"></i></span></ion-item>    
-            <label class="item" ng-if="!isChecking && !vocabulary_status.isNetAvailableRemote">Controllo Rete</label> 
-            <label class="item-icon-right" ng-if="isChecking">Controllo Rete<span><i class="icon ion-loop"></i></span></label>   
+            <ion-item class="item"            ng-if="!isChecking && !vocabulary_status.isNetAvailableRemote">Controllo Rete</ion-item>    
+            <ion-item class="item-icon-right" ng-if="isChecking ">Controllo Rete<span><i class="icon ion-loop"></i></span></ion-item>    
             
             <!--DOWNLOAD RETE-->
             <ion-item class="item-icon-right" ng-if="vocabulary_status.isNetAvailableLocale">Download Rete<span><i class="icon ion-checkmark-circled"></i></span></ion-item>    
@@ -43,12 +43,5 @@
             
 
     </ion-content>
-    
-    <ion-footer-bar class="bar-positive">
-        <div class="button-bar">        
-            <button class="bu button button-custom button-block button-positive" ng-click="closeModalSubmit()">CANCELLA</button>
-            <!--<button class="button button-full button-positive" ng-disabled="!vocabulary_status.isNetAvailableLocale" ng-click="startNewSession()">{{labelSubmit}}</button>-->        
-        </div>          
-    </ion-footer-bar>  
     
 </ion-modal-view>

--- a/www/templates/recognition.html
+++ b/www/templates/recognition.html
@@ -3,7 +3,7 @@
     <ion-nav-bar class="bar-positive">    
         <ion-nav-buttons side="left">
             <button class="button button-header-big" ng-if="!sessionname.length" ui-sref="home"><i class="ion-home"></i>
-            <button class="button button-header-big" ng-if="sessionname.length"  ui-sref="manage_training({foldername:foldername, backState:'vocabulary'})"></i>Back</button>
+            <button class="button button-header-big" ng-if="sessionname.length" ng-click="onStopTesting()"></i>Back</button>
         </ion-nav-buttons> 
 
         <ion-nav-buttons side="right">

--- a/www/templates/vocabulary.html
+++ b/www/templates/vocabulary.html
@@ -4,14 +4,6 @@
         {{headerTitle}}
     </ion-header-bar>      
     
-<!--    <ion-nav-title> {{ pageTitle }} </ion-nav-title>-->
-    
-<!--    <ion-nav-bar class="bar-positive">    
-       <ion-nav-back-button ui-sref="home">
-           <i class="ion-home"></i>
-       </ion-nav-back-button>    
-     </ion-nav-bar>    -->
-       
     <ion-nav-buttons side="left">
         <button class="button button-header-big" ui-sref="home">
            <i class="ion-home"></i>
@@ -25,12 +17,11 @@
     </ion-nav-buttons>  
     
     <ion-content class="padding">
-<!--        <h1 style="text-align: center;"></h1><br/>-->
-        
+       
         <button class="button button-outline button-tall button-block button-large button-positive" ui-sref="manage_commands({modeId:enum_showvoccommands, foldername:foldername, backState:'vocabulary'})" >{{labelEditTrainVocabulary}}</button>
         
         <button class="button button-outline button-tall button-block button-large button-positive" ng-if="!incompleteRecordings" ng-disabled="isDefault" ui-sref="manage_recordings({foldername:foldername, backState:'vocabulary'})" >{{labelManageSession}}</button>
-        <button class="button button-tall button-block button-large button-royal"               ng-if="incompleteRecordings" ng-disabled="isDefault" ui-sref="manage_recordings({foldername:foldername, backState:'vocabulary'})" >{{labelManageSession}}</button>
+        <button class="button button-tall button-block button-large button-royal"                   ng-if="incompleteRecordings" ng-disabled="isDefault" ui-sref="manage_recordings({foldername:foldername, backState:'vocabulary'})" >{{labelManageSession}}</button>
         
         <button class="button button-outline button-tall button-block button-large button-positive" ui-sref="voicebank({elems2display:enum_show_vb_voc, foldername:foldername, backState:'vocabulary'})" >{{labelRecordVoice}}</button>
         
@@ -40,20 +31,6 @@
             <div class="input-label">RETE ATTIVA</div>
             <select ng-model="selectedNet" ng-change="updateSelectedNet(selectedNet)" ng-options="item.label for item in existingNets track by item.value"></select>            
         </label>   
-        
-<!--        <ion-toggle
-            ng-disabled="!status.modelExist"
-            ng-checked="status.modelLoaded"
-            ng-click="loadModel(status.modelLoaded)"
-            ng-model="status.modelLoaded"
-            class="toggle-tall toggle-positive item item-text-wrap">
-            {{labelLoadVocabulary}}
-        </ion-toggle>  -->
-        
-        <!--<button class="button button-block button-large button-positive" ng-if="modelLoaded" ui-sref="training">{{}}</button>-->
-        
-        <br/><br/> 
-        <br/><br/> 
 
     </ion-content>
   


### PR DESCRIPTION
NEW FEATURES: created several vocabulary errors' recovery processes.
when are missing: 
 - vocabulary.json				=> ask user whether correcting  (retrieving info from the first net_xxxxxx) or deleting the voc (then send to vocabularies)
 - net_xxxxx.json 				=> remove its pb
 - net_xxxxx.pb are missing.	=> remove its json

NEW BEHAVIOUR: nets' sLabel are now limited to USER or COMMON ADAPTED. several recoding to implement this

BUG-FIX: when creating a new voc as a copy of an existing one.  sModelFileName is now set to "".
BUG-FIX: when checking the training progress. did not clear timer in catch
BUG-FIX: after testing a net, it remained the loaded one, and next loadNet failed (as it pointed to a temp dir that was deleted).
Now, while exiting, RecognitionCtrl unload the tested one and reassign the previous one (if exist)

NEW ENUM:  ENUMS.VOCABULARY.NETJSONFILE_NOTEXIST to manage when a net_xxxx.json is missing


VocabularySrv recoded

 - NEW METHOD RuntimeStatusSrv::getUserVocabularyName  returns selected voc foldername
 - RuntimeStatusSrv::loadVocabulary massively recoded to manage exception's recovery


VocabularySrv massively recoded

 - ADDED: 		recoverMissingVocJsonFile
				recoverMissingNetJsonFile
				recoverMissingNetPbFile
				deleteTrainVocabulary
				getTrainVocabularyFolder

 - REMOVED:		existFeaturesTrainSession (since there could be more recordings [now in a common folder] than features files)

 - MODIFIED:	getTrainVocabulary(path, ignorerecover): may now recover from the following error ENUMS.VOCABULARY.JSONFILE_NOTEXIST or reject it to the caller.

				getTrainVocabularySelectedNet rejects { mycode:ErrorSrv.ENUMS.VOCABULARY.NETJSONFILE_NOTEXIST / NETPBFILE_NOTEXIST, 
														mydata:retvoc{voc:{}, net:{}/null}, 
														message:"....."}
											  providing data so far obtained and helping caller to manage the recovery process.