### PR TITLE
version 0.4.0, code:13: manage bluetooth headsets in recognition and recordings

### DIFF
--- a/OT/java/AudioDevicesManager2.java
+++ b/OT/java/AudioDevicesManager2.java
@@ -1,0 +1,382 @@
+package com.allspeak.utility;
+
+import android.util.Log;
+//import com.allspeak.BuildConfig;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.media.AudioManager;
+
+import android.media.AudioDeviceInfo;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothHeadset;
+import android.bluetooth.BluetoothProfile;
+import android.content.BroadcastReceiver;
+ 
+import android.bluetooth.BluetoothAdapter;
+
+import android.media.AudioDeviceCallback;
+import android.media.AudioDeviceInfo;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.allspeak.ENUMS;
+import com.allspeak.ERRORS;
+import com.allspeak.utility.Messaging;
+import org.apache.cordova.CallbackContext;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Set;
+
+import com.allspeak.utility.ArrayList2d;
+import com.allspeak.utility.BluetoothHeadsetManager;
+import com.allspeak.utility.BluetoothHeadsetUtils;
+import com.allspeak.utility.BluetoothHeadsetManager.onBluetoothHeadSetListener;
+
+public class AudioDevicesManager extends BluetoothHeadsetUtils
+{
+    private static final String LOG_TAG         = "AudioDevicesManager";
+    
+    Context mContext                            = null;
+    AudioManager mAudioManager                  = null;
+    boolean isHeadSetConnected                  = false;
+    boolean isSCOEnabled                        = false;
+    private CallbackContext callbackContext     = null;
+    
+    private BluetoothHeadsetUtils mBTHeadSetUtils = null;
+    
+    private BluetoothHeadset mBluetoothHeadset;
+    private BluetoothAdapter mBluetoothAdapter          = null;
+    private BluetoothHeadsetManager mBTHeadSetManager;
+   
+    IntentFilter intentFilterSCO                = new IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED);
+    IntentFilter intentFilterBTHSCONN           = new IntentFilter(BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED);    
+    
+    ArrayList2d<AudioDeviceInfo> mAd            = new ArrayList2d<AudioDeviceInfo>();
+    
+    private myAudioDeviceCallback mAudioDeviceCallback  = new myAudioDeviceCallback();
+    
+    //=========================================================================================================================
+    public AudioDevicesManager(Context context, AudioManager audiomanager)
+    {
+        super(context);
+
+        mAd                 = getAudioDevices();
+//        registerReceivers(true);
+//        mAudioManager.startBluetoothSco();  
+
+//        if (mBTHeadSetManager == null)
+//                mBTHeadSetManager = new BluetoothHeadsetManager(mContext);
+//
+//        mBTHeadSetManager.addListener(mHeadsetCallback);
+//
+//        // if BT is turn on then we move next step
+//        if(mBTHeadSetManager.hasEnableBluetooth())
+//        {
+//            mBTHeadSetManager.connectionToProxy();
+//        }        
+    }
+//9179  all.speak1 ------  AllSpeak@2018
+    public void onHeadsetDisconnected(){};
+
+    public void onHeadsetConnected(){};
+
+    public void onScoAudioDisconnected(){};
+
+    public void onScoAudioConnected(){};   
+    
+    //=========================================================================================================================
+    public ArrayList2d<AudioDeviceInfo> getAudioDevices()
+    {
+        AudioDeviceInfo[] inad = mAudioManager.getDevices(AudioManager.GET_DEVICES_INPUTS);
+        int l = inad.length;
+        for(int d=0; d<l; d++) mAd.Add(inad[d], 0);
+        
+        AudioDeviceInfo[] outad = mAudioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
+        l = outad.length;
+        for(int d=0; d<l; d++) mAd.Add(outad[d], 1);
+       
+        return mAd;
+    }    
+    
+    public String[][] exportAudioDevicesNames()
+    {
+        int lin     = mAd.getNumCols(0);
+        int lout    = mAd.getNumCols(1);
+        int max     = Math.max(lin, lout);
+        
+        String[][] str_ad = new String[2][max];
+        
+        for(int d=0; d<lin; d++)    str_ad[0][d] = mAd.get(0,d).getProductName().toString();
+        for(int d=0; d<lout; d++)   str_ad[1][d] = mAd.get(1,d).getProductName().toString();
+        
+        return str_ad;
+    }
+    
+    public JSONObject exportAudioDevicesJSON() throws JSONException
+    {
+        try
+        {
+            JSONObject info = new JSONObject();
+            info.put("type", ENUMS.AUDIODEVICES_INFO);
+
+            JSONArray input = new JSONArray();
+            JSONArray output = new JSONArray();
+
+            int lin     = mAd.getNumCols(0);
+            int lout    = mAd.getNumCols(1);
+            int max     = Math.max(lin, lout);
+
+            JSONObject elem;
+            for(int d=0; d<lin; d++)
+            {
+                AudioDeviceInfo adinfo = mAd.get(0,d);
+                elem            = new JSONObject();
+                elem.put("name", adinfo.getProductName().toString());
+                elem.put("type", adinfo.getType());
+                elem.put("channels", adinfo.getChannelCounts());
+
+                input.put(elem);
+            }
+            for(int d=0; d<lout; d++)
+            {
+                AudioDeviceInfo adinfo = mAd.get(1,d);
+                elem            = new JSONObject();
+                elem.put("name", adinfo.getProductName().toString());
+                elem.put("type", adinfo.getType());
+                elem.put("channels", adinfo.getChannelCounts());
+
+                output.put(elem);
+            }
+
+            info.put("input", input);
+            info.put("output", output);  
+            return info;
+        }
+        catch(Exception e)
+        {
+            e.printStackTrace(); 
+            throw (e);
+        }
+    }
+    
+    public AudioDeviceInfo[][] exportAudioDevice()
+    {
+        int lin     = mAd.getNumCols(0);
+        int lout    = mAd.getNumCols(1);
+        int max     = Math.max(lin, lout);
+
+        AudioDeviceInfo[][] ad = new AudioDeviceInfo[2][max];
+        
+        for(int d=0; d<lin; d++)    ad[0][d] = mAd.get(0,d);
+        for(int d=0; d<lout; d++)   ad[1][d] = mAd.get(1,d);        
+        
+        return ad;
+    }
+
+    public boolean isBTHSconnected()
+    {
+        mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        if (mBluetoothAdapter == null) 
+        {
+            // Device does not support Bluetooth
+            
+        }        
+//        Set<BluetoothDevice> bondedDevices = mBluetoothAdapter.getBondedDevices();
+        return true;
+    }
+    
+    public void startBTHSConnection(boolean start)
+    {
+        if(start)
+        {
+            startBluetooth();
+        }
+        else
+        {
+            stopBluetooth();
+        }
+//        if(start)
+//        {
+//            mAudioManager.setSpeakerphoneOn(false);
+//            mAudioManager.setBluetoothScoOn(true);            
+//            mAudioManager.startBluetoothSco();
+//        }
+//        else
+//        {
+//            mAudioManager.stopBluetoothSco();
+//            mAudioManager.setBluetoothScoOn(false);
+//            mAudioManager.setSpeakerphoneOn(true);
+//        }
+    }
+    
+    public void setCallback(CallbackContext callbackcontext)
+    {
+        callbackContext = callbackcontext;
+    }
+
+    public void onPause()
+    {
+        registerReceivers(false);
+    }
+    
+    public void onResume()
+    {
+        registerReceivers(true);
+    }
+    //=================================================================================================
+    //=================================================================================================
+    //=================================================================================================
+    //=================================================================================================
+    //=================================================================================================
+    private void registerReceivers(boolean reg)
+    {
+        if(reg)
+        {
+            mContext.registerReceiver(mBluetoothScoReceiver, intentFilterSCO);
+//            mContext.registerReceiver(mBTHSConnReceiver, intentFilterBTHSCONN);  
+//            mAudioManager.registerAudioDeviceCallback(mAudioDeviceCallback, null);
+        }
+        else
+        {
+            mContext.unregisterReceiver(mBluetoothScoReceiver);
+//            mContext.unregisterReceiver(mBTHSConnReceiver);  
+//            mAudioManager.unregisterAudioDeviceCallback(mAudioDeviceCallback);            
+        }
+    }
+    
+    //called when headset is connected/disconnected
+    private BroadcastReceiver mBTHSConnReceiver = new BroadcastReceiver() 
+    {
+        @Override
+        public void onReceive(Context context, Intent intent) 
+        {
+            int state               = intent.getIntExtra(BluetoothProfile.EXTRA_STATE, -1);
+            BluetoothDevice device  = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+            String deviceName       = device.getName();
+            
+            try
+            {
+                isHeadSetConnected  = false;
+                JSONObject info     = new JSONObject(); 
+                
+                switch (state)
+                {
+                    case BluetoothProfile.STATE_CONNECTED:
+                        info.put("type", ENUMS.HEADSET_CONNECTED);  
+                        isHeadSetConnected = true;
+                       Log.d(LOG_TAG, "BT headset " + deviceName + " connected");
+                        break;
+
+                    case BluetoothProfile.STATE_DISCONNECTED:
+                        info.put("type", ENUMS.HEADSET_DISCONNECTED);  
+                        isHeadSetConnected = false;
+                       Log.d(LOG_TAG, "BT headset " + deviceName + " disconnected");
+                        break;
+
+                    case BluetoothProfile.STATE_CONNECTING:
+                        info.put("type", ENUMS.HEADSET_CONNECTING);  
+                        isHeadSetConnected = false;
+                       Log.d(LOG_TAG, "BT headset " + deviceName + " connecting");
+                        break;
+
+                    case BluetoothProfile.STATE_DISCONNECTING:
+                        info.put("type", ENUMS.HEADSET_DISCONNECTING);  
+                        isHeadSetConnected = false;
+                       Log.d(LOG_TAG, "BT headset " + deviceName + " disconnecting");
+                        break;
+                }
+
+                Messaging.sendUpdate2Web(callbackContext, info, true);
+            }
+            catch (JSONException e){e.printStackTrace();}              
+        }        
+    };
+
+    //called when a SCO connection has changed
+    private BroadcastReceiver mBluetoothScoReceiver = new BroadcastReceiver() 
+    {
+        @Override
+        public void onReceive(Context context, Intent intent) 
+        {
+            int state = intent.getIntExtra(AudioManager.EXTRA_SCO_AUDIO_STATE, -1);
+            
+            try
+            {
+                isSCOEnabled  = false;
+                JSONObject info     = new JSONObject(); 
+                
+                if(state == AudioManager.SCO_AUDIO_STATE_ERROR)
+                    Messaging.sendErrorString2Web(callbackContext, "headset connection error", ERRORS.HEADSET_ERROR, true);
+                else
+                {
+                    switch (state)
+                    {
+                        case AudioManager.SCO_AUDIO_STATE_CONNECTED:
+                            info.put("type", ENUMS.HEADSET_CONNECTED);  
+                            isSCOEnabled = true;
+                           Log.d(LOG_TAG, "SCO connected");
+                            break;
+
+                        case AudioManager.SCO_AUDIO_STATE_DISCONNECTED:
+                            info.put("type", ENUMS.HEADSET_DISCONNECTED);  
+                            isSCOEnabled = false;
+                           Log.d(LOG_TAG, "SCO disconnected");
+                            
+                            break;
+
+                        case AudioManager.SCO_AUDIO_STATE_CONNECTING:
+                            info.put("type", ENUMS.HEADSET_CONNECTING);  
+                            isSCOEnabled = false;
+                            break;
+                    }
+
+                    Messaging.sendUpdate2Web(callbackContext, info, true);
+                }
+            }
+            catch (JSONException e){e.printStackTrace();}              
+        }
+    };      
+    
+    // AUDIO DEVICES LISTENER
+    private class myAudioDeviceCallback extends AudioDeviceCallback 
+    {
+        public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) 
+        {
+            for (int d=0; d<addedDevices.length; d++)
+            {
+                AudioDeviceInfo ad  = addedDevices[d];
+                if(ad.isSink()) mAd.Add(ad, 1);
+                else            mAd.Add(ad, 0);
+                
+               Log.d(LOG_TAG, "added audio devices: " + addedDevices[d].getProductName().toString());
+            }
+        }
+
+        public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) 
+        {
+            for (int d=0; d<removedDevices.length; d++)
+            {
+                AudioDeviceInfo ad  = removedDevices[d];
+                String name         = ad.getProductName().toString();
+                int col;
+                if(ad.isSink()) col = 1;
+                else            col = 0;
+                
+                for(int dd=0; dd<mAd.getNumCols(col); dd++)
+                {
+                    AudioDeviceInfo thisad  = mAd.get(col,dd);
+                    String thisname         = thisad.getProductName().toString();                        
+                    if(name == thisname)    mAd.remove(col, dd);
+                }
+                
+               Log.d(LOG_TAG, "removed audio devices: " + name);
+            }
+        }
+    }  
+    //=================================================================================================
+}

--- a/OT/java/AudioDevicesManager_old.java
+++ b/OT/java/AudioDevicesManager_old.java
@@ -1,0 +1,453 @@
+package com.allspeak.utility;
+
+import android.util.Log;
+//import com.allspeak.BuildConfig;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.media.AudioManager;
+
+import android.media.AudioDeviceInfo;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothHeadset;
+import android.bluetooth.BluetoothProfile;
+import android.content.BroadcastReceiver;
+ 
+import android.bluetooth.BluetoothAdapter;
+
+import android.media.AudioDeviceCallback;
+import android.media.AudioDeviceInfo;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.allspeak.ENUMS;
+import com.allspeak.ERRORS;
+import com.allspeak.utility.Messaging;
+import org.apache.cordova.CallbackContext;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Set;
+
+import com.allspeak.utility.ArrayList2d;
+import com.allspeak.utility.BluetoothHeadsetManager;
+import com.allspeak.utility.BluetoothHeadsetManager.onBluetoothHeadSetListener;
+
+public class AudioDevicesManager 
+{
+    private static final String LOG_TAG         = "AudioDevicesManager";
+    
+    Context mContext                            = null;
+    AudioManager mAudioManager                  = null;
+    boolean isHeadSetConnected                  = false;
+    boolean isSCOEnabled                        = false;
+    private CallbackContext callbackContext     = null;
+    
+    private BluetoothHeadset mBluetoothHeadset;
+    private BluetoothAdapter mBluetoothAdapter          = null;
+    private BluetoothHeadsetManager mBTHeadSetManager;
+   
+    IntentFilter intentFilterSCO                = new IntentFilter(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED);
+    IntentFilter intentFilterBTHSCONN           = new IntentFilter(BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED);    
+    
+    ArrayList2d<AudioDeviceInfo> mAd            = new ArrayList2d<AudioDeviceInfo>();
+    
+    private myAudioDeviceCallback mAudioDeviceCallback  = new myAudioDeviceCallback();
+    
+    //=========================================================================================================================
+    public AudioDevicesManager(Context context, AudioManager audiomanager)
+    {
+        mContext            = context;
+        mAudioManager       = audiomanager;
+
+        mAd                 = getAudioDevices();
+//        registerReceivers(true);
+//        mAudioManager.startBluetoothSco();  
+
+        if (mBTHeadSetManager == null)
+                mBTHeadSetManager = new BluetoothHeadsetManager(mContext);
+
+        mBTHeadSetManager.addListener(mHeadsetCallback);
+
+        // if BT is turn on then we move next step
+        if(mBTHeadSetManager.hasEnableBluetooth())
+        {
+            mBTHeadSetManager.connectionToProxy();
+        }        
+
+    }
+    
+    public onBluetoothHeadSetListener mHeadsetCallback = new onBluetoothHeadSetListener() 
+    {
+
+        @Override
+        public void disconnectedToProxy()
+        {
+            verifyHeadSetState(false,null);
+        }
+
+        @Override
+        public void connectedToProxy(BluetoothHeadset aBluetoothHeadset)
+        {
+            mBluetoothHeadset = aBluetoothHeadset;
+            if(mBluetoothHeadset != null)
+            {
+                verifyHeadSetState(false,null);
+            }
+        }
+    };    
+    
+    private void verifyHeadSetState(boolean flag, BluetoothDevice device)
+    {
+        //TODO Wait for other wise result getting wrong
+        try {
+                Thread.sleep(500);
+        } catch (InterruptedException e) {
+                e.printStackTrace();
+        }
+
+        int state = 0;
+//        HeadSetModel btheasetdmodel = null;
+        if(flag)
+        {
+            // STATE_DISCONNECTED	0
+            // STATE_CONNECTED 		2
+
+            // STATE_CONNECTING		1
+            // STATE_DISCONNECTING	3
+
+            state = mBluetoothHeadset.getConnectionState(device);
+           Log.d(AudioDevicesManager.class.getCanonicalName(), "State :" + state);
+        }
+        else
+        {
+//            AudioManager am = getAudioManager();
+            state = (mAudioManager.isBluetoothA2dpOn() == true) ? 1 : 0;
+        }
+
+        switch (state)
+        {
+            case 0:
+            {
+               Log.d(AudioDevicesManager.class.getCanonicalName(), "isBluetoothA2dpOff()");
+//				btheasetdmodel= new HeadSetModel().setState(0).setStateName("BluetoothA2dpOff");
+                break;
+            }
+            case 1:
+            {
+               Log.d(AudioDevicesManager.class.getCanonicalName(), "isBluetoothA2dpOn()");
+//				btheasetdmodel= new HeadSetModel().setState(1).setStateName("BluetoothA2dpOn");
+                break;
+            }
+            case 2:
+            {
+               Log.d(AudioDevicesManager.class.getCanonicalName(), "isBluetoothA2dpOn()");
+//				btheasetdmodel= new HeadSetModel().setState(1).setStateName("BluetoothA2dpOn");
+                break;
+            }
+            default:
+                break;
+        }
+
+        // TODO Please call setBTHeadsetInfo instead of setHeadsetInfo
+//		DeviceAudioOutputManager.getInstance(getActiveContext()).setBTHeadsetInfo(btheasetdmodel);
+//
+//		if(hasController())
+//		{
+//			mAudioController.updateHeadSetInfo(btheasetdmodel.getState(), btheasetdmodel);
+//		}
+
+    }    
+    
+    
+    public AudioDevicesManager(Context context, AudioManager audiomanager, CallbackContext callbackcontext)
+    {
+        this(context, audiomanager);
+        callbackContext = callbackcontext;
+    }
+    //=========================================================================================================================
+    public ArrayList2d<AudioDeviceInfo> getAudioDevices()
+    {
+        AudioDeviceInfo[] inad = mAudioManager.getDevices(AudioManager.GET_DEVICES_INPUTS);
+        int l = inad.length;
+        for(int d=0; d<l; d++) mAd.Add(inad[d], 0);
+        
+        AudioDeviceInfo[] outad = mAudioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS);
+        l = outad.length;
+        for(int d=0; d<l; d++) mAd.Add(outad[d], 1);
+       
+        return mAd;
+    }    
+    
+    public String[][] exportAudioDevicesNames()
+    {
+        int lin     = mAd.getNumCols(0);
+        int lout    = mAd.getNumCols(1);
+        int max     = Math.max(lin, lout);
+        
+        String[][] str_ad = new String[2][max];
+        
+        for(int d=0; d<lin; d++)    str_ad[0][d] = mAd.get(0,d).getProductName().toString();
+        for(int d=0; d<lout; d++)   str_ad[1][d] = mAd.get(1,d).getProductName().toString();
+        
+        return str_ad;
+    }
+    
+    public JSONObject exportAudioDevicesJSON() throws JSONException
+    {
+        try
+        {
+            JSONObject info = new JSONObject();
+            info.put("type", ENUMS.AUDIODEVICES_INFO);
+
+            JSONArray input = new JSONArray();
+            JSONArray output = new JSONArray();
+
+            int lin     = mAd.getNumCols(0);
+            int lout    = mAd.getNumCols(1);
+            int max     = Math.max(lin, lout);
+
+            JSONObject elem;
+            for(int d=0; d<lin; d++)
+            {
+                AudioDeviceInfo adinfo = mAd.get(0,d);
+                elem            = new JSONObject();
+                elem.put("name", adinfo.getProductName().toString());
+                elem.put("type", adinfo.getType());
+                elem.put("channels", adinfo.getChannelCounts());
+
+                input.put(elem);
+            }
+            for(int d=0; d<lout; d++)
+            {
+                AudioDeviceInfo adinfo = mAd.get(1,d);
+                elem            = new JSONObject();
+                elem.put("name", adinfo.getProductName().toString());
+                elem.put("type", adinfo.getType());
+                elem.put("channels", adinfo.getChannelCounts());
+
+                output.put(elem);
+            }
+
+            info.put("input", input);
+            info.put("output", output);  
+            return info;
+        }
+        catch(Exception e)
+        {
+            e.printStackTrace(); 
+            throw (e);
+        }
+    }
+    
+    public AudioDeviceInfo[][] exportAudioDevice()
+    {
+        int lin     = mAd.getNumCols(0);
+        int lout    = mAd.getNumCols(1);
+        int max     = Math.max(lin, lout);
+
+        AudioDeviceInfo[][] ad = new AudioDeviceInfo[2][max];
+        
+        for(int d=0; d<lin; d++)    ad[0][d] = mAd.get(0,d);
+        for(int d=0; d<lout; d++)   ad[1][d] = mAd.get(1,d);        
+        
+        return ad;
+    }
+
+    public boolean isBTHSconnected()
+    {
+        mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+        if (mBluetoothAdapter == null) 
+        {
+            // Device does not support Bluetooth
+            
+        }        
+//        Set<BluetoothDevice> bondedDevices = mBluetoothAdapter.getBondedDevices();
+        return true;
+    }
+    
+    public void startBTHSConnection(boolean start)
+    {
+        if(start)
+        {
+            mAudioManager.setSpeakerphoneOn(false);
+            mAudioManager.setBluetoothScoOn(true);            
+            mAudioManager.startBluetoothSco();
+        }
+        else
+        {
+            mAudioManager.stopBluetoothSco();
+            mAudioManager.setBluetoothScoOn(false);
+            mAudioManager.setSpeakerphoneOn(true);
+        }
+    }
+    
+    public void setCallback(CallbackContext callbackcontext)
+    {
+        callbackContext = callbackcontext;
+    }
+
+    public void onPause()
+    {
+        registerReceivers(false);
+    }
+    
+    public void onResume()
+    {
+        registerReceivers(true);
+    }
+    //=================================================================================================
+    //=================================================================================================
+    //=================================================================================================
+    //=================================================================================================
+    //=================================================================================================
+    private void registerReceivers(boolean reg)
+    {
+        if(reg)
+        {
+            mContext.registerReceiver(mBluetoothScoReceiver, intentFilterSCO);
+//            mContext.registerReceiver(mBTHSConnReceiver, intentFilterBTHSCONN);  
+//            mAudioManager.registerAudioDeviceCallback(mAudioDeviceCallback, null);
+        }
+        else
+        {
+            mContext.unregisterReceiver(mBluetoothScoReceiver);
+//            mContext.unregisterReceiver(mBTHSConnReceiver);  
+//            mAudioManager.unregisterAudioDeviceCallback(mAudioDeviceCallback);            
+        }
+    }
+    
+    //called when headset is connected/disconnected
+    private BroadcastReceiver mBTHSConnReceiver = new BroadcastReceiver() 
+    {
+        @Override
+        public void onReceive(Context context, Intent intent) 
+        {
+            int state               = intent.getIntExtra(BluetoothProfile.EXTRA_STATE, -1);
+            BluetoothDevice device  = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+            String deviceName       = device.getName();
+            
+            try
+            {
+                isHeadSetConnected  = false;
+                JSONObject info     = new JSONObject(); 
+                
+                switch (state)
+                {
+                    case BluetoothProfile.STATE_CONNECTED:
+                        info.put("type", ENUMS.HEADSET_CONNECTED);  
+                        isHeadSetConnected = true;
+                       Log.d(LOG_TAG, "BT headset " + deviceName + " connected");
+                        break;
+
+                    case BluetoothProfile.STATE_DISCONNECTED:
+                        info.put("type", ENUMS.HEADSET_DISCONNECTED);  
+                        isHeadSetConnected = false;
+                       Log.d(LOG_TAG, "BT headset " + deviceName + " disconnected");
+                        break;
+
+                    case BluetoothProfile.STATE_CONNECTING:
+                        info.put("type", ENUMS.HEADSET_CONNECTING);  
+                        isHeadSetConnected = false;
+                       Log.d(LOG_TAG, "BT headset " + deviceName + " connecting");
+                        break;
+
+                    case BluetoothProfile.STATE_DISCONNECTING:
+                        info.put("type", ENUMS.HEADSET_DISCONNECTING);  
+                        isHeadSetConnected = false;
+                       Log.d(LOG_TAG, "BT headset " + deviceName + " disconnecting");
+                        break;
+                }
+
+                Messaging.sendUpdate2Web(callbackContext, info, true);
+            }
+            catch (JSONException e){e.printStackTrace();}              
+        }        
+    };
+
+    //called when a SCO connection has changed
+    private BroadcastReceiver mBluetoothScoReceiver = new BroadcastReceiver() 
+    {
+        @Override
+        public void onReceive(Context context, Intent intent) 
+        {
+            int state = intent.getIntExtra(AudioManager.EXTRA_SCO_AUDIO_STATE, -1);
+            
+            try
+            {
+                isSCOEnabled  = false;
+                JSONObject info     = new JSONObject(); 
+                
+                if(state == AudioManager.SCO_AUDIO_STATE_ERROR)
+                    Messaging.sendErrorString2Web(callbackContext, "headset connection error", ERRORS.HEADSET_ERROR, true);
+                else
+                {
+                    switch (state)
+                    {
+                        case AudioManager.SCO_AUDIO_STATE_CONNECTED:
+                            info.put("type", ENUMS.HEADSET_CONNECTED);  
+                            isSCOEnabled = true;
+                           Log.d(LOG_TAG, "SCO connected");
+                            break;
+
+                        case AudioManager.SCO_AUDIO_STATE_DISCONNECTED:
+                            info.put("type", ENUMS.HEADSET_DISCONNECTED);  
+                            isSCOEnabled = false;
+                           Log.d(LOG_TAG, "SCO disconnected");
+                            
+                            break;
+
+                        case AudioManager.SCO_AUDIO_STATE_CONNECTING:
+                            info.put("type", ENUMS.HEADSET_CONNECTING);  
+                            isSCOEnabled = false;
+                            break;
+                    }
+
+                    Messaging.sendUpdate2Web(callbackContext, info, true);
+                }
+            }
+            catch (JSONException e){e.printStackTrace();}              
+        }
+    };      
+    
+    // AUDIO DEVICES LISTENER
+    private class myAudioDeviceCallback extends AudioDeviceCallback 
+    {
+        public void onAudioDevicesAdded(AudioDeviceInfo[] addedDevices) 
+        {
+            for (int d=0; d<addedDevices.length; d++)
+            {
+                AudioDeviceInfo ad  = addedDevices[d];
+                if(ad.isSink()) mAd.Add(ad, 1);
+                else            mAd.Add(ad, 0);
+                
+               Log.d(LOG_TAG, "added audio devices: " + addedDevices[d].getProductName().toString());
+            }
+        }
+
+        public void onAudioDevicesRemoved(AudioDeviceInfo[] removedDevices) 
+        {
+            for (int d=0; d<removedDevices.length; d++)
+            {
+                AudioDeviceInfo ad  = removedDevices[d];
+                String name         = ad.getProductName().toString();
+                int col;
+                if(ad.isSink()) col = 1;
+                else            col = 0;
+                
+                for(int dd=0; dd<mAd.getNumCols(col); dd++)
+                {
+                    AudioDeviceInfo thisad  = mAd.get(col,dd);
+                    String thisname         = thisad.getProductName().toString();                        
+                    if(name == thisname)    mAd.remove(col, dd);
+                }
+                
+               Log.d(LOG_TAG, "removed audio devices: " + name);
+            }
+        }
+    }  
+    //=================================================================================================
+}

--- a/OT/java/AudioInOutChangeReceiver.java
+++ b/OT/java/AudioInOutChangeReceiver.java
@@ -1,0 +1,322 @@
+package com.allspeak.utility;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothDevice;
+import android.bluetooth.BluetoothHeadset;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.media.AudioManager;
+import android.text.TextUtils;
+import android.util.Log;
+import java.lang.StringBuilder;
+
+//import com.test.example.BirdersApplication;
+//import com.test.example.controller.AudioHeadSetController;
+//import com.test.example.controller.BluetoothHeadsetManager;
+//import com.test.example.controller.BluetoothHeadsetManager.onBluetoothHeadSetListener;
+//import com.test.example.controller.DeviceAudioOutputManager;
+//import com.test.example.interfce.ILogger;
+//import com.test.example.model.HeadSetModel;
+//import com.test.example.util.StorageManager;
+
+public class AudioInOutChangeReceiver extends BroadcastReceiver {
+
+	private static AudioInOutChangeReceiver mInstance;
+
+//	private AudioHeadSetController mAudioController;
+
+	private static final String ACTION_HEADSET_PLUG_STATE = "android.intent.action.HEADSET_PLUG";
+
+	private AudioManager mAudioManager;
+
+	private BluetoothHeadsetManager mBTHeadSetManager;
+
+	private Context mContext;
+
+	private BluetoothHeadset mBluetoothHeadset;
+
+	@Override
+	public String getTAG()
+	{
+            return AudioInOutChangeReceiver.class.getCanonicalName();
+	}
+
+	private AudioInOutChangeReceiver(Context aContext)
+	{
+		if(BuildConfig.DEBUG) Log.d(getTAG(), "AudioInOutChangeReceiver()");
+
+		if (mContext == null)
+			mContext = aContext;
+
+		initiBTHeadSetConfiguration();
+	}
+
+	private AudioInOutChangeReceiver()
+	{
+
+	}
+
+	public static AudioInOutChangeReceiver getInstance(Context aContext)
+	{
+		if(mInstance == null)
+		{
+			mInstance = new AudioInOutChangeReceiver(aContext);
+		}
+		return mInstance;
+	}
+
+	public static void voidInstance()
+	{
+		mInstance = null;
+	}
+
+	public Context getActiveContext()
+	{
+		return mContext;
+	}
+
+//	public AudioInOutChangeReceiver addAudioController(AudioHeadSetController aController)
+//	{
+//		if(mAudioController == null)
+//		this.mAudioController = aController;
+//		return mInstance;
+//	}
+
+//	public boolean hasController()
+//	{
+//		return mAudioController != null ? true : false;
+//	}
+
+//	public AudioInOutChangeReceiver removeAudioController()
+//	{
+//
+//		if(BuildConfig.DEBUG) Log.d(getTAG(), "removeAudioController()");
+//
+//		// reset BT Head set Configuration
+//		resetBTHeadSetConfiguration();
+//
+//		if(this.mAudioController != null)
+//		{
+//			this.mAudioController  = null;
+//		}
+//		return mInstance;
+//	}
+
+	private void initiBTHeadSetConfiguration()
+	{
+		if (mBTHeadSetManager == null)
+			mBTHeadSetManager = new BluetoothHeadsetManager(mContext);
+
+		mBTHeadSetManager.addListener(mHeadsetCallback);
+
+		// if BT is turn on then we move next step
+		if(mBTHeadSetManager.hasEnableBluetooth())
+		{
+			mBTHeadSetManager.connectionToProxy();
+		}
+	}
+
+	private void resetBTHeadSetConfiguration()
+	{
+		mBTHeadSetManager.disconnectProxy();
+	}
+
+
+	@Override
+	public void onReceive(Context context, Intent intent)
+	{
+//		if(BirdersApplication.getInstance().getDebug_mode())
+//			StorageManager.dumpIntent(getTAG(),intent);
+
+		// initial audio manager
+		initiAudioManager(context);
+
+		final String action = intent.getAction();
+		// check action should not empty
+		if(TextUtils.isEmpty(action))return;
+
+		 //Broadcast Action: Wired Headset plugged in or unplugged.
+		 if (action.equals(ACTION_HEADSET_PLUG_STATE))
+		 {
+			 updateHeadSetDeviceInfo(context, intent);
+
+		} else if (BluetoothDevice.ACTION_ACL_CONNECTED.equals(action)
+				|| BluetoothDevice.ACTION_ACL_DISCONNECTED.equals(action)
+				|| BluetoothAdapter.ACTION_STATE_CHANGED.equals(action))
+		 {
+
+			updateBTHeadSetDeviceInfo(context, intent);
+		 }
+
+	}
+
+	public void updateHeadSetDeviceInfo(Context context, Intent intent)
+	{
+		 //0 for unplugged, 1 for plugged.
+		 int state = intent.getIntExtra("state", -1);
+
+		 StringBuilder stateName = null;
+
+		 //Headset type, human readable string
+		 String name = intent.getStringExtra("name");
+
+		 // - 1 if headset has a microphone, 0 otherwise, 1 mean h2w
+		 int microPhone = intent.getIntExtra("microphone", -1);
+
+		 switch (state)
+		 {
+                    case 0:
+                        stateName = new StringBuilder("Headset is unplugged");
+                       Log.d(getTAG(),stateName.toString());
+                        break;
+                    case 1:
+                        stateName = new StringBuilder("Headset is plugged");
+                       Log.d(getTAG(),stateName.toString());
+                        break;
+                    default:
+                       Log.d(getTAG(), "I have no idea what the headset state is");
+		 }
+
+//	 	HeadSetModel tempModel = new HeadSetModel().setState(state).setStateName(stateName.toString()).setHandSetName(name).setMicroPhone(microPhone);
+//
+//	 	// update the prefrence key 'KEY_HEADSET_MODEL'  for headset info
+//		DeviceAudioOutputManager.getInstance(context).setHeadsetInfo(tempModel);
+//
+//		if(hasController())
+//		{
+//			mAudioController.updateHeadSetInfo(tempModel.getState(), tempModel);
+//		}
+	}
+
+	public void updateBTHeadSetDeviceInfo(Context context, Intent intent)
+	{
+		if(intent != null)
+		{
+			BluetoothDevice device = intent.getParcelableExtra(BluetoothDevice.EXTRA_DEVICE);
+			if(device != null)
+			{
+				verifyHeadSetState(true,device);
+			}
+		}
+	}
+	public onBluetoothHeadSetListener mHeadsetCallback = new onBluetoothHeadSetListener() {
+
+		@Override
+		public void disconnectedToProxy()
+		{
+			verifyHeadSetState(false,null);
+		}
+
+		@Override
+		public void connectedToProxy(BluetoothHeadset aBluetoothHeadset)
+		{
+			mBluetoothHeadset = aBluetoothHeadset;
+			if(mBluetoothHeadset != null)
+			{
+				verifyHeadSetState(false,null);
+			}
+		}
+	};
+
+	private void verifyHeadSetState(boolean flag,BluetoothDevice device)
+	{
+
+		//TODO Wait for other wise result getting wrong
+		try {
+			Thread.sleep(500);
+		} catch (InterruptedException e) {
+			e.printStackTrace();
+		}
+
+		int state = 0;
+		HeadSetModel btheasetdmodel = null;
+		if(flag)
+		{
+			// STATE_DISCONNECTED	0
+			// STATE_CONNECTED 		2
+
+			// STATE_CONNECTING		1
+			// STATE_DISCONNECTING	3
+
+			state = mBluetoothHeadset.getConnectionState(device);
+			if(BuildConfig.DEBUG) Log.d(getTAG(), "State :" + state);
+		}
+		else
+		{
+			AudioManager am = getAudioManager();
+			state = (am.isBluetoothA2dpOn() == true) ? 1 : 0;
+		}
+
+		switch (state)
+		{
+			case 0:
+			{
+				if(BuildConfig.DEBUG) Log.d(getTAG(), "isBluetoothA2dpOff()");
+//				btheasetdmodel= new HeadSetModel().setState(0).setStateName("BluetoothA2dpOff");
+				break;
+			}
+			case 1:
+			{
+				if(BuildConfig.DEBUG) Log.d(getTAG(), "isBluetoothA2dpOn()");
+//				btheasetdmodel= new HeadSetModel().setState(1).setStateName("BluetoothA2dpOn");
+				break;
+			}
+			case 2:
+			{
+				if(BuildConfig.DEBUG) Log.d(getTAG(), "isBluetoothA2dpOn()");
+//				btheasetdmodel= new HeadSetModel().setState(1).setStateName("BluetoothA2dpOn");
+				break;
+			}
+			default:
+				break;
+		}
+
+	 	// TODO Please call setBTHeadsetInfo instead of setHeadsetInfo
+//		DeviceAudioOutputManager.getInstance(getActiveContext()).setBTHeadsetInfo(btheasetdmodel);
+//
+//		if(hasController())
+//		{
+//			mAudioController.updateHeadSetInfo(btheasetdmodel.getState(), btheasetdmodel);
+//		}
+
+	}
+
+	private AudioManager initiAudioManager(Context aContext)
+	{
+		if(mAudioManager == null)
+		mAudioManager = (AudioManager) aContext.getSystemService(Context.AUDIO_SERVICE);
+		return mAudioManager;
+	}
+
+	public AudioManager getAudioManager()
+	{
+		return mAudioManager != null ? mAudioManager : initiAudioManager(getActiveContext()) ;
+	}
+
+	public void queryAudioManagerForRouted()
+	{
+		AudioManager am = getAudioManager();
+		if (am.isBluetoothA2dpOn())
+		{
+		    // Adjust output for Bluetooth.
+			if(BuildConfig.DEBUG) Log.d(getTAG(), "isBluetoothA2dpOn()");
+
+		} else if (am.isSpeakerphoneOn())
+		{
+		    // Adjust output for Speakerphone.
+			if(BuildConfig.DEBUG) Log.d(getTAG(), "isSpeakerphoneOn()");
+
+		} else if (am.isWiredHeadsetOn())
+		{
+		    // Adjust output for headsets
+			if(BuildConfig.DEBUG) Log.d(getTAG(), "isWiredHeadsetOn()");
+
+		}
+		else
+		{
+
+		}
+	}
+
+}

--- a/OT/java/BluetoothHeadsetManager.java
+++ b/OT/java/BluetoothHeadsetManager.java
@@ -1,0 +1,74 @@
+package com.allspeak.utility;
+
+import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothHeadset;
+import android.bluetooth.BluetoothProfile;
+import android.content.Context;
+
+public class BluetoothHeadsetManager
+{
+    public interface onBluetoothHeadSetListener
+    {
+        public void connectedToProxy(BluetoothHeadset aBluetoothHeadset);
+        public void disconnectedToProxy();
+    }
+
+    private BluetoothHeadset mBluetoothHeadset;
+    private BluetoothAdapter mBluetoothAdapter;
+    private Context mContext;
+    public onBluetoothHeadSetListener mCallBackListener;
+
+    public BluetoothHeadsetManager(Context mContext)
+    {
+        this.mContext = mContext;
+        mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
+    }
+
+    public void addListener(onBluetoothHeadSetListener aListener)
+    {
+        this.mCallBackListener = aListener;
+    }
+
+    public boolean hasEnableBluetooth()
+    {
+        return (mBluetoothAdapter.isEnabled()) ? true : false;
+    }
+
+    public void connectionToProxy()
+    {
+        mBluetoothAdapter.getProfileProxy(mContext, mProfileListener, BluetoothProfile.HEADSET);
+    }
+
+    public void disconnectProxy()
+    {
+        mBluetoothAdapter.closeProfileProxy(BluetoothProfile.HEADSET, mBluetoothHeadset);
+    }
+
+    private BluetoothHeadset getBTHandSetInstance()
+    {
+        return mBluetoothHeadset;
+    }
+
+    private BluetoothProfile.ServiceListener mProfileListener = new BluetoothProfile.ServiceListener()
+    {
+        @Override
+        public void onServiceConnected(int profile, BluetoothProfile proxy)
+        {
+            if (profile == BluetoothProfile.HEADSET)
+            {
+                mBluetoothHeadset = (BluetoothHeadset) proxy;
+                mCallBackListener.connectedToProxy(getBTHandSetInstance());
+            }
+        }
+
+        @Override
+        public void onServiceDisconnected(int profile)
+        {
+            if (profile == BluetoothProfile.HEADSET)
+            {
+                mBluetoothHeadset = null;
+                mCallBackListener.disconnectedToProxy();
+            }
+        }
+    };
+}

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,0 +1,20 @@
+
+TODO:
+
+Importare file wav
+Levare alert, catch inutili
+
+FATTI:
+
+•	Creare un nuovo vocabolario come copia di uno esistente….durante :
+o	il crea nuovo 
+o	il salva comandi di uno esistente
+•	Quando cancello il voc selezionato, seleziono il default
+•	cancellare reti derivate quando riregistro la prima
+•	quando cancello un custom commando=> cancellare tutte le reti di tutti i vocabolari che lo contengono
+•	disattivare tasto training se non ci sono registrazioni a sufficienza e colorare divers quello delle registrazioni
+•	quando modifico lista commandi in un voc=> cancellare tutte le sue reti 
+•	In managetraining e in vocabulary sente se perdo la connessione e, rispettivamente, torno in vocabulary e disabliita il “addestra“
+•	Screenshot sessione da cancellare
+•	Mettere testi popup in UITextSrv
+•	Verificare procedura headset

--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget android-versionCode="12" id="com.allspeak" version="0.3.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget android-versionCode="13" id="com.allspeak" version="0.4.0" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>AllSpeak</name>
     <description>
         A communication assistive device.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "allspeak",
-  "version": "1.1.1",
+  "version": "0.4.0",
   "description": "allspeak: An Ionic project",
   "dependencies": {
     "@ionic-native/core": "^4.5.3",
@@ -56,8 +56,8 @@
       "cordova-plugin-device": {},
       "cordova-plugin-app-version": {},
       "cordova-plugin-tts": {},
-      "cordova-plugin-speechrecognition": {},
-      "cordova-plugin-app-update": {}
+      "cordova-plugin-app-update": {},
+      "cordova-plugin-speechrecognition": {}
     }
   }
 }

--- a/www/css/style.css
+++ b/www/css/style.css
@@ -39,6 +39,10 @@
     width:90px !important;
 }
 
+.button-larger{
+    width:75px !important;
+}
+
 .button-tall{
     height:90px !important;
 }  

--- a/www/index.html
+++ b/www/index.html
@@ -20,6 +20,7 @@
 
         <script src="js/filters/filters.js"></script>    
 
+        <script src="js/services/BluetoothSrv.js"></script>
         <script src="js/services/ClockSrv.js"></script>
         <script src="js/services/CommandsSrv.js"></script>
         <script src="js/services/EnumsSrv.js"></script>

--- a/www/js/controllers/InitCheckCtrl.js
+++ b/www/js/controllers/InitCheckCtrl.js
@@ -18,7 +18,7 @@
  * finally, before sending to home, load the active vocabulary (if exists)
  */
  
-function InitCheckCtrl($scope, $q, $state, $ionicPlatform, $ionicModal, $ionicPopup, $cordovaSplashscreen, InitAppSrv, RuntimeStatusSrv, RemoteAPISrv, EnumsSrv, UITextsSrv)
+function InitCheckCtrl($scope, $q, $state, $ionicPlatform, $ionicModal, $ionicPopup, $cordovaSplashscreen, InitAppSrv, RuntimeStatusSrv, RemoteAPISrv, BluetoothSrv, EnumsSrv, UITextsSrv)
 {
     $scope.want2beAssistedText              = "";
     $scope.want2beAssistedText2             = "";
@@ -69,27 +69,24 @@ function InitCheckCtrl($scope, $q, $state, $ionicPlatform, $ionicModal, $ionicPo
         .then(function(modal) 
         {
             $scope.modalInsertApiKey = modal;
-            // setup modal insert api key
-//            return $ionicModal.fromTemplateUrl('templates/modal/specifyGender.html', {
-//                                            scope: $scope,
-//                                            animation: 'slide-in-up',
-//                                            backdropClickToClose: false,
-//                                            hardwareBackButtonClose: false})
-//        })
-//        .then(function(modal) 
-//        {
-//            $scope.modalSpecifyGender = modal;
-            if(RemoteAPISrv.hasInternet())
-                RemoteAPISrv.checkAppUpdate($scope.startApp, null);
-            else
-            {
-                $ionicPopup.alert({title: UITextsSrv.labelAlertTitle, template: UITextsSrv.SETUP.noConnectionText});
-                $scope.endCheck('home'); 
-            }
+//            return $ionicModal.fromTemplateUrl('templates/modal/specifyGender.html', {scope: $scope, animation: 'slide-in-up', backdropClickToClose: false, hardwareBackButtonClose: false})}).then(function(modal) {  $scope.modalSpecifyGender = modal;}
+            BluetoothSrv.initBluetooth($scope.checkAppUpdate);
         });  
     });
     
     $scope.$on('$ionicView.leave', function(){if($scope.deregisterFunc)   $scope.deregisterFunc();});    
+   
+    // called by initBluetooth callback (plugin -> BluetoothSrv -> here)
+    $scope.checkAppUpdate = function()
+    {
+        if(RemoteAPISrv.hasInternet())
+            RemoteAPISrv.checkAppUpdate($scope.startApp, null);
+        else
+        {
+            $ionicPopup.alert({title: UITextsSrv.labelAlertTitle, template: UITextsSrv.SETUP.noConnectionText});
+            $scope.endCheck('home'); 
+        }        
+    };
    
     // callback from RemoteAPISrv.checkAppUpdate (after update-finish or no-update)
     $scope.startApp = function(isServerOn) 

--- a/www/js/services/BluetoothSrv.js
+++ b/www/js/services/BluetoothSrv.js
@@ -1,0 +1,140 @@
+/*
+ * manage Bluetooth connection
+ * ISSUE: I force autoconnect to be FALSE during initialization to prevent HS hangup
+ * 
+ */
+
+function BluetoothSrv($q)
+{
+    pluginInterface         = null;
+    plugin_enum             = null;
+    initAppSrv              = null;    
+
+    audio_devices           = {};
+    
+    isBluetoothAvailable    = false;
+    
+    mExistHeadsetConnected  = false;
+    mIsOnHeadsetSco         = false;
+    mAutoConnect            = false;
+    
+    mActiveHeadSetName       = "";
+    ctrl_callback           = null;
+    
+    //==========================================================================
+    init = function(bluetooth_params, plugin, initappserv)
+    {  
+        pluginInterface     = plugin;
+        plugin_enum         = pluginInterface.ENUM.PLUGIN;
+        initAppSrv          = initappserv;   
+        
+        mAutoConnect        = bluetooth_params.autoconnect;
+    };
+    //=========================================================================
+    // retrieve list of audio devices
+    // register callback for onHeadset change
+    // check whether activating headset retrieval    
+    initBluetooth = function(ctrl_clb)
+    {
+        ctrl_callback = ctrl_clb;
+        return pluginInterface.getAudioDevices()// returns : {input:[{"name": , "types":  , channels: }], output:[{"name": , "types":  , channels: }]}
+        .then(function(ad)
+        {
+            audio_devices = ad;
+            pluginInterface.initBluetooth(onInitBluetooth);
+        })
+        .catch(function(error){ 
+            audio_devices = {};
+            return $q.reject(error);              
+        });
+    };
+    
+    // called by plugin interface...inform InitCheckCtrl
+    onInitBluetooth = function(res)
+    {
+        isBluetoothAvailable = res;
+        ctrl_callback();
+    };
+    //=========================================================================
+    // from controller to plugin
+    // data are sent to the caller in the same format as cordova.fireWindowEvent("headsetstatus", {data: data});
+    getBluetoothStatus = function()
+    {
+        return pluginInterface.getBluetoothStatus()
+        .then(function(status)
+        {
+            mExistHeadsetConnected  = status.mExistHeadsetConnected;
+            mIsOnHeadsetSco         = status.mIsOnHeadsetSco;
+            mAutoConnect            = status.mAutoConnect;
+            mActiveHeadSetName      = status.mActiveHeadSetName;    
+            mActiveHeadSetAddress   = status.mActiveHeadSetAddress;    
+            
+            return {"data":{"mExistHeadsetConnected":mExistHeadsetConnected,
+                            "mIsOnHeadsetSco"       :mIsOnHeadsetSco,
+                            "mAutoConnect"          :mAutoConnect,
+                            "mActiveHeadSetName"    :mActiveHeadSetName,
+                            "mActiveHeadSetAddress" :mActiveHeadSetAddress}};
+        });     
+    };
+
+    enableHeadSet = function(enable)
+    {
+        mAutoConnect = enable;
+        return pluginInterface.enableHeadSet(enable);
+    };    
+    //=========================================================================
+    // PLUGIN => WL
+    //=========================================================================
+    onHSStatusChange = function(event)
+    {
+        mActiveHeadSetName = event.device_name;
+        switch(event.type)
+        {
+//            case plugin_enum.HEADSET_CONNECTED:
+            case plugin_enum.HEADSET_EXIST:
+                mExistHeadsetConnected  = true;                
+                break; 
+            
+            case plugin_enum.HEADSET_DISCONNECTED:
+                mExistHeadsetConnected  = false;
+                mIsOnHeadsetSco         = false;
+                break;              
+                
+            case plugin_enum.HEADSET_CONNECTING:
+                break;              
+                
+            case plugin_enum.AUDIOSCO_CONNECTED:
+                mIsOnHeadsetSco         = true;                
+                break;              
+                
+            case plugin_enum.AUDIOSCO_DISCONNECTED:
+                mIsOnHeadsetSco         = false;                
+                break;              
+        }
+    };    
+    //=========================================================================
+    // from controller to here
+    //=========================================================================
+    existHeadset = function(threshold)
+    {
+        return mExistHeadsetConnected;
+    };
+    //=========================================================================
+    isHeadsetConnected = function(threshold)
+    {
+        return mIsOnHeadsetSco;
+    };
+    //==========================================================================
+    // public interface
+    //==========================================================================
+    return {
+        init                        : init,
+        initBluetooth               : initBluetooth,
+        getBluetoothStatus          : getBluetoothStatus,
+        existHeadset                : existHeadset,
+        isHeadsetConnected          : isHeadsetConnected,
+        enableHeadSet               : enableHeadSet
+    };    
+    //==========================================================================
+}
+main_module.service('BluetoothSrv', BluetoothSrv);

--- a/www/js/services/RemoteAPISrv.js
+++ b/www/js/services/RemoteAPISrv.js
@@ -63,7 +63,7 @@ main_module.service('RemoteAPISrv', function($http, $q, $cordovaTransfer, $cordo
 //        ServerCfg.url   = "http://192.168.1.6:8095";          // casa
 //        ServerCfg.url   = "http://192.168.36.28:8095";        // OVERWRITE FOR DEBUG
 //        ServerCfg.url   = "http://192.168.43.69:8095";        // Moto G3
-        ServerCfg.url   = "http://api.allspeak.eu";           // produzione
+        ServerCfg.url   = "https://api.allspeak.eu";           // produzione
 //        ServerCfg.url   = "http://api.allspeak.staging.eu";   // staging
 //        ServerCfg.url   = "http://10.255.7.79";               // OVERWRITE FOR DEBUG
         Enums           = window.AppUpdate.ENUM.PLUGIN;

--- a/www/js/services/UITextsSrv.js
+++ b/www/js/services/UITextsSrv.js
@@ -131,6 +131,8 @@ function UITextsSrv()
     service.RECOGNITION.labelUncertainResults                   = "ripeti il comando";
     service.RECOGNITION.labelStartRecognition                   = "AVVIA RICONOSCIMENTO";
     service.RECOGNITION.labelStopRecognition                    = "INTERROMPI RICONOSCIMENTO";
+    service.RECOGNITION.labelHSDisconnectedWhileRecognizing     = "IL MICROFONO SI E\' DISCONNESSO";
+    service.RECOGNITION.labelHeadsetAbsent                      = "Microfono assente";
     
     //==========================================================================
     return service;

--- a/www/json/defaults.json
+++ b/www/json/defaults.json
@@ -85,7 +85,7 @@
                 "nConcatenateMaxChunks":10,
                 "nNormalize":true,
                 "fNormalizationFactor":32767,
-                "nDataDest":204,
+                "nDataDest":206,
                 "nDataSubSample":1,
                 "nChunkMaxLengthMS":20000,
                 "sOutputPath":""
@@ -147,6 +147,10 @@
             "get_training_session_network":"training-sessions",
             "delete_training_session":"training-sessions",
             "api_key_reset":"api_key_reset"}
+        },
+        "bluetooth":{
+            "autoconnect":false,
+            "devices_list":[]
         },
         "system":{
             "plugin_interface_name":"window.speechrecognition"

--- a/www/templates/recognition.html
+++ b/www/templates/recognition.html
@@ -21,7 +21,7 @@
     <ion-content>
         <div class="list">
             
-            <ion-item class="item-button-right">VOCE : Intensità/soglia...RESET >
+            <ion-item class="item-button-right">VOCE : Intensità/soglia...RESET:
                 <button class="button text-big text-center button-wide" ng-class="isSpeaking == 'ON' ? 'button-balanced' : 'button-positive'" ng-click="resetVADThreshold(true);">{{voiceDB}}/{{thresholdDB}}</button>
             </ion-item>
             
@@ -34,8 +34,12 @@
                 </div>            
                                
             </div>
+
+            <ion-item class="item-button-right">{{mActiveHeadSetName}}
+                <button class="button button-larger" ng-disabled="!mExistHeadsetConnected || isvoicemonitoring" ng-class="mIsOnHeadsetSco ? 'button-assertive' : 'button-balanced'" ng-click="toogleHeadSet(true);">{{mIsOnHeadsetSco ? 'STOP' : 'USA'}}</button>
+            </ion-item>
             
-            <ion-toggle class="item" ng-model="headsetSelected" ng-disabled="isvoicemonitoring || !headsetAvailable" ng-click="useHS(headsetSelected)">Attiva Microfono esterno</ion-toggle>             
+            <!--<ion-toggle class="item" ng-model="mIsOnHeadsetSco" ng-disabled="isvoicemonitoring || !mExistHeadsetConnected" ng-click="useHS(mIsOnHeadsetSco)">MIC: {{mActiveHeadSetName}}</ion-toggle>-->             
             
             <ion-list>
                 <ion-item class="item-button-right" ng-repeat="chunk in chunksList"> {{chunk}}

--- a/www/templates/record_sequence.html
+++ b/www/templates/record_sequence.html
@@ -1,4 +1,4 @@
-<ion-view view-title="REGISTRA" hide-back-button="true">
+<ion-view view-title="Comando : {{sentence.title}} {{labelSeqOrder}}" hide-back-button="true">
     
     
     <ion-footer-bar class="bar-positive">
@@ -6,17 +6,12 @@
             <button class="button button-block button-large button-balanced icon icon-left text-big" ng-disabled="!existNewFile" ng-click="confirm()">{{nextButtonLabel}}</button>       
             <button class="button button-block button-large button-energized icon icon-left text-big" ng-if="isSequence" ng-click="skip()">{{skipButtonLabel}}</button>       
             <button class="button button-block button-large button-assertive icon icon-left text-big" ng-click="cancel()">{{exitButtonLabel}}</button>       
-<!--            <button class="button button-block button-large button-balanced icon icon-left ion-android-archive text-big" ng-disabled="!existNewFile" ng-click="confirm()">{{nextButtonLabel}}</button>       
-            <button class="button button-block button-large button-energized icon icon-left ion-arrow-left-a text-big" ng-if="isSequence" ng-click="skip()">{{skipButtonLabel}}</button>       
-            <button class="button button-block button-large button-assertive icon icon-left ion-arrow-left-a text-big" ng-click="cancel()">{{exitButtonLabel}}</button>       -->
         </div>        
     </ion-footer-bar>       
     
-    
     <ion-content>
-
         
-        <label class="item" >{{sentence.title}}<span class="badge" ng-if="isSequence">{{labelSeqOrder}}</span></label>
+        <!--<label class="item" >{{sentence.title}}<span class="badge" ng-if="isSequence">{{labelSeqOrder}}</span></label>-->
         
         <div class="card" ng-if="preserveOriginal">   
             <div class="item item-divider">VERSIONE ATTUALE</div>            
@@ -37,18 +32,17 @@
             </div>         
         </div>
             
-        <!--<label class="item">Voice Activity:<span class="badge">{{voice_power}}</span></label>-->        
-<!--        <label class="item">VOLUME<span class="badge">{{volume}}</span></label>-->
+        <label class="item">Volume voce [db]:<span class="badge">{{voiceDB}}</span></label>
+
+        <ion-item class="item-button-right">{{mActiveHeadSetName}}
+            <button class="button button-larger" ng-disabled="!mExistHeadsetConnected || isvoicemonitoring" ng-class="mIsOnHeadsetSco ? 'button-assertive' : 'button-balanced'" ng-click="toogleHeadSet(true);">{{mIsOnHeadsetSco ? 'STOP' : 'USA'}}</button>
+        </ion-item>        
+        
         <div class="item range">
             <i class="icon ion-volume-low"></i>
             <input type="range" name="volume" ng-model="volume" ng-change="onChangeVolume(volume)">
             <i class="icon ion-volume-high"></i>
         </div>
-        
-<!--        <div class="button-bar">        
-            <button class="button button-block button-large button-balanced icon icon-left ion-android-archive" ng-disabled="!existNewFile" ng-click="confirm()">{{nextButtonLabel}}</button>       
-            <button class="button button-block button-large button-energized icon icon-left ion-arrow-left-a" ng-if="isSequence" ng-click="skip()">{{skipButtonLabel}}</button>       
-            <button class="button button-block button-large button-assertive icon icon-left ion-arrow-left-a" ng-click="cancel()">{{exitButtonLabel}}</button>       
-        </div>         -->
+
   </ion-content>
 </ion-view>


### PR DESCRIPTION
controllers get headset status through direct promise.
while headset status is updated at runtime through the plugin unified callback. 
if headset disconnects while recognizing -> stop recognition

TTS is used only if there is a connection. TODO: plan alternative behavior when disconnected

SequenceRecord now reports headset management and voice decibels.

App points https

sequencerecord capturing terminates automatically when the buffer is over (as implemented in the plugin)